### PR TITLE
Add `app.json` file

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "name": "genStr",
+  "description": "Generate string session using this bot",
+  "env": {
+    "BOT_TOKEN": {"description": "Get this from https://t.me/BotFather"},
+    "API_KEY": {"description": "Heroku API Key from https://dashboard.heroku.com/account"},
+    "APP_NAME": {
+      "description": "Enter name of your Heroku app",
+      "required": false}
+  }
+}


### PR DESCRIPTION
Added `app.json` file for deploying to Heroku.
## Why this?
Anyone who clicked the button to deploy `genStr` to Heroku got "`app.json` not provided" error. So, this PR is created to resolve the issue.
## ChangeLog
Added a name, description, and a small `ENV` in file.
#### [-----Example-----] ####
```json
{
  "name": "genStr",
  "description": "Generate string session using this bot."
}
```
> @Krishna-Singhal please review this PR.